### PR TITLE
Codex/font size options

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Else, if you prefer the graphical editor, use the menu to add the resource:
 | font_size ***(optional)*** | string or number |  |  | Base font size for the card. Plain numbers are treated as pixels.
 | heading_font_size ***(optional)*** | string or number |  |  | Font size for the station heading. Plain numbers are treated as pixels.
 | train_font_size ***(optional)*** | string or number |  |  | Font size for each train row. Plain numbers are treated as pixels.
+| status_font_size ***(optional)*** | string or number |  |  | Font size for train status text. Plain numbers are treated as pixels.
 | details_font_size ***(optional)*** | string or number |  |  | Font size for the calling-at details. Plain numbers are treated as pixels.
 
 ```yaml
@@ -85,6 +86,7 @@ limit: 3
 font_size: 24px
 heading_font_size: 30px
 train_font_size: 24px
+status_font_size: 22px
 details_font_size: 20px
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ Else, if you prefer the graphical editor, use the menu to add the resource:
 | type ***(required)*** | string |  | v0.0.1 | `custom:nationalrail-status-card`.
 | entity ***(required)*** | string |  | v0.0.1 | The entity being monitored
 | limit ***(optional)*** | number |  | v0.0.1 | The maximum number of trains to show at once. If absent then defaults to the API default.
+| font_size ***(optional)*** | string or number |  |  | Base font size for the card. Plain numbers are treated as pixels.
+| heading_font_size ***(optional)*** | string or number |  |  | Font size for the station heading. Plain numbers are treated as pixels.
+| train_font_size ***(optional)*** | string or number |  |  | Font size for each train row. Plain numbers are treated as pixels.
+| details_font_size ***(optional)*** | string or number |  |  | Font size for the calling-at details. Plain numbers are treated as pixels.
+
+```yaml
+type: custom:nationalrail-status-card
+entity: sensor.train_schedule_nem_wat
+limit: 3
+font_size: 24px
+heading_font_size: 30px
+train_font_size: 24px
+details_font_size: 20px
+```
 
 ## Development
 

--- a/src/index-editor.js
+++ b/src/index-editor.js
@@ -33,6 +33,7 @@ export default class NationalrailStatusCardEditor extends EditorForm {
       { controls: [{ label: "Base font size", configValue: "font_size", type: FormControlType.Textbox }] },
       { controls: [{ label: "Heading font size", configValue: "heading_font_size", type: FormControlType.Textbox }] },
       { controls: [{ label: "Train font size", configValue: "train_font_size", type: FormControlType.Textbox }] },
+      { controls: [{ label: "Status font size", configValue: "status_font_size", type: FormControlType.Textbox }] },
       { controls: [{ label: "Details font size", configValue: "details_font_size", type: FormControlType.Textbox }] },
     ])
   };

--- a/src/index-editor.js
+++ b/src/index-editor.js
@@ -30,6 +30,10 @@ export default class NationalrailStatusCardEditor extends EditorForm {
     return this.renderForm([
       { controls: [{ label: "Entity", configValue: "entity", type: FormControlType.Dropdown, items: filterTrainEntities(this._hass, getEntitiesByDomain(this._hass, "sensor")) }] },
       { controls: [{ label: "Number of trains to shown", configValue: "limit", type: FormControlType.Textbox }] },
+      { controls: [{ label: "Base font size", configValue: "font_size", type: FormControlType.Textbox }] },
+      { controls: [{ label: "Heading font size", configValue: "heading_font_size", type: FormControlType.Textbox }] },
+      { controls: [{ label: "Train font size", configValue: "train_font_size", type: FormControlType.Textbox }] },
+      { controls: [{ label: "Details font size", configValue: "details_font_size", type: FormControlType.Textbox }] },
     ])
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,7 @@ class NationalrailStatusCard extends LitElement {
       ["font_size", "--nationalrail-card-font-size"],
       ["heading_font_size", "--nationalrail-card-heading-font-size"],
       ["train_font_size", "--nationalrail-card-train-font-size"],
+      ["status_font_size", "--nationalrail-card-status-font-size"],
       ["details_font_size", "--nationalrail-card-details-font-size"]
     ];
     return mappings

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ class NationalrailStatusCard extends LitElement {
     if (this._config?.limit) {
       let limit = 0;
       if (typeof this._config.limit === 'number') {
-        limit = config.limit;
+        limit = this._config.limit;
       }
       else if (typeof this._config.limit === "string") {
         limit = parseInt(this._config.limit);
@@ -68,10 +68,11 @@ class NationalrailStatusCard extends LitElement {
     if (trains && trains.length > 0) {
       items = trains.map(this.renderTrain);
     }
+    const styleVariables = this.getStyleVariables();
     return html`<ha-card>
       <div id="content">
-      <div id="nationalrail-status">
-      <h2>${this.attributes?.station}</h3>
+      <div id="nationalrail-status" style=${styleVariables}>
+      <h2>${this.attributes?.station}</h2>
       ${items}
       </div>
       </div>
@@ -101,6 +102,35 @@ class NationalrailStatusCard extends LitElement {
       <h4>Calling at ${train.destinations.map(dest => destinationPresent(dest, train.expected)).join(", ")}</h4 >
     </div >
       `
+  }
+
+  getStyleVariables() {
+    const mappings = [
+      ["font_size", "--nationalrail-card-font-size"],
+      ["heading_font_size", "--nationalrail-card-heading-font-size"],
+      ["train_font_size", "--nationalrail-card-train-font-size"],
+      ["details_font_size", "--nationalrail-card-details-font-size"]
+    ];
+    return mappings
+      .map(([configKey, cssVariable]) => {
+        const value = this.normalizeSize(this._config?.[configKey]);
+        return value ? `${cssVariable}: ${value};` : "";
+      })
+      .join("");
+  }
+
+  normalizeSize(value) {
+    if (value === undefined || value === null || value === "") {
+      return "";
+    }
+    if (typeof value === "number") {
+      return `${value}px`;
+    }
+    const trimmed = value.trim();
+    if (/^\d+(\.\d+)?$/.test(trimmed)) {
+      return `${trimmed}px`;
+    }
+    return trimmed;
   }
 
 }

--- a/src/style.js
+++ b/src/style.js
@@ -5,6 +5,7 @@ import { css } from 'lit';
 const style = css`
 #nationalrail-status {
   padding:16px;
+  font-size: var(--nationalrail-card-font-size, var(--ha-font-size-m, 14px));
 }
 .train {
   display:flex;
@@ -13,6 +14,7 @@ const style = css`
   border:1px white solid;
   border-radius: 5px;
   margin: 2px 0px;
+  font-size: var(--nationalrail-card-train-font-size, 1em);
 }
 .top-heading {
   display:flex;
@@ -39,7 +41,14 @@ const style = css`
 h3, h4 {
   margin:0;
 }
+h2 {
+  font-size: var(--nationalrail-card-heading-font-size, 1.5em);
+}
+h3 {
+  font-size: var(--nationalrail-card-train-heading-font-size, 1.15em);
+}
 h4 {
+  font-size: var(--nationalrail-card-details-font-size, .95em);
   font-style: italic;
   font-weight: 500;
 }

--- a/src/style.js
+++ b/src/style.js
@@ -28,6 +28,7 @@ const style = css`
 }
 .scheduled-status {
   padding-left: 5px;
+  font-size: var(--nationalrail-card-status-font-size, 1em);
 }
 .platform-container {
   display:flex;

--- a/src/style.js
+++ b/src/style.js
@@ -25,10 +25,10 @@ const style = css`
 .scheduled-container {
   display:flex;
   flex-basis:100%;
+  font-size: var(--nationalrail-card-status-font-size, 1em);
 }
 .scheduled-status {
   padding-left: 5px;
-  font-size: var(--nationalrail-card-status-font-size, 1em);
 }
 .platform-container {
   display:flex;


### PR DESCRIPTION
Great work! I've forked this as I have a kiosk and I needed a bit more visibility so added some customizations options if you'd like to implement. I also ran it by copilot which spotted small nags so these were fixed as well..

Thanks again

## Summary

Adds optional font size settings for:

- `font_size`
- `heading_font_size`
- `train_font_size`
- `details_font_size`

Plain numeric values are treated as pixels, while CSS values like `24px`, `1.2em`, or `var(...)` are passed through.

## Other small fixes

While testing the change, this also fixes:

- numeric `limit` values reading from an undefined `config` variable
- the station heading closing with `</h3>` instead of `</h2>`

## Validation

Tested the equivalent generated bundle locally in Home Assistant on a train dashboard with larger display font sizes.

I could not run `npm run build` in the current environment because Node/NPM are not installed, so the generated `dist` bundle may need rebuilding before release.